### PR TITLE
Allow command arguments

### DIFF
--- a/example/example.cabal
+++ b/example/example.cabal
@@ -18,6 +18,7 @@ library
   exposed-modules:     Lib
                      , Lib.FooTask
                      , Lib.BarTask
+                     , Lib.ArgsTask
   build-depends:       base >= 4.7 && < 5
                      , kale
   default-language:    Haskell2010

--- a/example/src/Lib/ArgsTask.hs
+++ b/example/src/Lib/ArgsTask.hs
@@ -1,6 +1,7 @@
 module Lib.ArgsTask where
 
 data Args = Args { name :: String, age :: Int }
+    deriving (Eq, Show, Read)
 
 task :: Args -> IO ()
 task args = do

--- a/example/src/Lib/ArgsTask.hs
+++ b/example/src/Lib/ArgsTask.hs
@@ -1,0 +1,8 @@
+module Lib.ArgsTask where
+
+data Args = Args { name :: String, age :: Int }
+
+task :: Args -> IO ()
+task args = do
+    putStrLn $ "Your name is: " ++ name args
+    print (age args)

--- a/kale.cabal
+++ b/kale.cabal
@@ -16,6 +16,7 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
+  ghc-options:         -Wall
   exposed-modules:     Kale
                      , Kale.Discover
   build-depends:       base >= 4.7 && < 5

--- a/src/Kale.hs
+++ b/src/Kale.hs
@@ -81,9 +81,11 @@ taskToSum task = taskName task ++ case taskArgs task of
     Just args -> stripArgs args
 
 stripArgs :: String -> String
-stripArgs x = case stripPrefix "data Args = Args" x of
-    Nothing -> error $ "stripArgs called with a weird string: " ++ x
-    Just a -> a
+stripArgs =
+    (' ' :)
+    . (++ "}")
+    . dropWhile (/= '{')
+    . takeWhile (/= '}')
 
 mkCaseOf :: Task -> String
 mkCaseOf task = concat

--- a/src/Kale.hs
+++ b/src/Kale.hs
@@ -7,21 +7,16 @@ module Kale where
 import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Maybe
-import           Data.Char
-import           Data.List
-import           Data.Maybe
-import           Data.String
-import           Data.Traversable          (for)
+import           Control.Monad.Trans.Maybe (MaybeT(..))
+import           Data.Char                 (isAlphaNum, isLower, isSpace,
+                                            isUpper, toUpper)
+import           Data.List                 (foldl', groupBy, intercalate, sort,
+                                            stripPrefix, isPrefixOf, find)
+import           Data.Maybe                (catMaybes)
 import           System.Directory          (doesDirectoryExist, doesFileExist,
                                             getDirectoryContents)
 import           System.Environment        (getArgs)
-import           System.Exit
 import           System.FilePath
-import           System.IO
-
-instance IsString ShowS where
-  fromString = showString
 
 data Task = Task
     { taskModule :: String
@@ -52,6 +47,7 @@ mkTaskModule src tasks = unlines
   , "{-# LANGUAGE DeriveGeneric #-}"
   , "{-# LANGUAGE DeriveAnyClass #-}"
   , "{-# LANGUAGE OverloadedStrings #-}"
+  , "{-# LANGUAGE RecordWildCards #-}"
   , ""
   , "module " ++ pathToModule src ++ " where"
   , ""
@@ -76,15 +72,35 @@ driver tasks = unlines $
 mkCommandSum :: [Task] -> String
 mkCommandSum [] = ""
 mkCommandSum tasks = "data Command = "
-    ++ intercalate "|" (map taskToSum tasks)
+    ++ intercalate " | " (map taskToSum tasks)
     ++ " deriving (Eq, Show, Read, Generic, ParseRecord)"
 
 taskToSum :: Task -> String
-taskToSum = taskName
+taskToSum task = taskName task ++ case taskArgs task of
+    Nothing -> ""
+    Just args -> stripArgs args
+
+stripArgs :: String -> String
+stripArgs x = case stripPrefix "data Args = Args" x of
+    Nothing -> error $ "stripArgs called with a weird string: " ++ x
+    Just a -> a
 
 mkCaseOf :: Task -> String
 mkCaseOf task = concat
-    [taskName task, " -> ", taskModule task, "Task.task"]
+    [ taskName task
+    , maybe "" (const "{..}") (taskArgs task)
+    , " -> "
+    , taskModule task
+    , "Task.task"
+    , case taskArgs task of
+        Nothing ->
+            ""
+        Just _ -> concat
+            [ " "
+            , taskModule task
+            , "Task.Args {..}"
+            ]
+    ]
 
 indent :: Int -> [String] -> [String]
 indent n = map (replicate n ' ' ++)
@@ -127,9 +143,8 @@ mkTask fileContent name mod_ = Task
 casify :: String -> String
 casify str = intercalate "_" $ groupBy (\a b -> isUpper a && isLower b) str
 
-
 findArgs :: String -> Maybe String
-findArgs file =  Nothing
+findArgs = find ("data Args" `isPrefixOf`) . decs
 
 decs :: String -> [String]
 decs = reverse . fmap (collapseSpace . concat . reverse) . foldl' go [] . lines

--- a/test/KaleSpec.hs
+++ b/test/KaleSpec.hs
@@ -24,6 +24,8 @@ spec = do
             casify "HelloWorld" `shouldBe` "Hello_World"
         it "acts strange with many caps letters" $
             casify "HTTPWorker" `shouldBe` "H_T_T_P_Worker"
+        -- the inputs to casify will always be module names, so the below should
+        -- not happen
         it "acts strange with initial lowercase" $
             casify "lowHigh" `shouldBe` "l_o_w_High"
 
@@ -56,14 +58,26 @@ spec = do
         it "is empty on empty task lists" $
             mkCommandSum [] `shouldBe` ""
         it "lists tasktnames properly" $
-            mkCommandSum [task0, task1] 
+            mkCommandSum [task0, task1]
+                `shouldBe` concat
+                    [ "data Command = Name { foo :: Int }"
+                    , " | Other_Name deriving (Eq, "
+                    , "Show, Read, Generic, ParseRecord)"
+                    ]
+
+    describe "mkCaseOf" $ do
+        it "works with args" $ do
+            mkCaseOf task0
                 `shouldBe`
-                    unwords ["data Command = Name|Other_Name deriving (Eq,",
-                        "Show, Read, Generic, ParseRecord)"]
+                    "Name{..} -> Module.FooTask.task Module.FooTask.Args {..}"
+        it "works without args" $ do
+            mkCaseOf task1
+                `shouldBe`
+                    "Other_Name -> Module1.FooTask.task"
 
     describe "mkTask" $ do
         it "is Nothing for taskArgs when fileContent is empty" $
-            mkTask "" "OtherName" "Module1.foo" `shouldBe` task1
+            mkTask "" "OtherName" "Module1.Foo" `shouldBe` task1
 
     describe "pathToModule" $ do
         it "parses directories and file extensions" $
@@ -73,12 +87,27 @@ spec = do
         it "pulls out taskModules and splits into newlines" $
             importList [task0, task1] `shouldBe`
                 unlines [
-                        "import qualified Module.fooTask",
-                        "import qualified Module1.fooTask"
+                        "import qualified Module.FooTask",
+                        "import qualified Module1.FooTask"
                         ]
-    
-                    
-                    
+
+    describe "findArgs" $ do
+        it "correctly finds arguments" $ do
+            findArgs args0
+                `shouldBe`
+                    Just "data Args = Args { fooId :: Int , barId :: Int }"
+
+args0 :: String
+args0 = unlines
+    [ "module ASdf where"
+    , ""
+    , "data Args"
+    , "  = Args"
+    , "  { fooId :: Int"
+    , "  , barId :: Int"
+    , "  }"
+    ]
+
 decs0 :: String
 decs0 = unlines
     [ "module Foo where"
@@ -112,8 +141,18 @@ decs3 = unlines
     , "}"
     ]
 
+decs4 :: String
+decs4 = unlines
+    [ "module Wat where"
+    , "data Args = Args"
+    , "  { fooName :: String"
+    , "  , fooAge  :: Int"
+    , "  }"
+    ]
+
+
 task0 :: Task
-task0 = Task "Module.foo" (Just "args0 args1") "Name"
+task0 = Task "Module.Foo" (Just "data Args = Args { foo :: Int }") "Name"
 
 task1 :: Task
-task1 = Task "Module1.foo" Nothing "Other_Name"
+task1 = Task "Module1.Foo" Nothing "Other_Name"


### PR DESCRIPTION
This PR allows the user to provide an `Args` datatype that represents the command line arguments.

The user would put the type in the module:

```haskell
module Lib.FooTask where

data Args = Args { fooName :: String }

task :: Args -> IO ()
task args = putStrLn (fooName args)
```

The corresponding command type gets:

```haskell
data Command = Foo { fooName :: String }
```

And when casing on it, we do:

```haskell
case cmd of
  Foo {..} -> Lib.FooTask.task Lib.FooTask.Args {..}
```