### PR TITLE
Rename PHONY to .PHONY to work properly with Gnu Make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ test:
 lint:
 	stack build hlint && stack exec -- hlint .
 
-PHONY: ghcid example-dump test hpc
+.PHONY: ghcid example-dump test hpc


### PR DESCRIPTION
Fixes #20.